### PR TITLE
Attempt to avoid the parallel threads printing 41,42,43.

### DIFF
--- a/java/04/threads/src/main/java/org/example/FanOutFanIn.java
+++ b/java/04/threads/src/main/java/org/example/FanOutFanIn.java
@@ -20,7 +20,7 @@ public class FanOutFanIn {
     static class FanOutFanInJob {
         ArrayList<Integer> items;
         ArrayList<Thread> threads;
-        int i;
+        volatile int i;
 
         public FanOutFanInJob(int count, int threads) {
             this.items = new ArrayList<Integer>(count);
@@ -31,10 +31,14 @@ public class FanOutFanIn {
             }
         }
 
-        private synchronized void printNext() {
+        private synchronized void printNext(int max) {
+
+            if(i>max) {
+                return;
+            }
             printItem(i);
             i++;
-            notify();
+            //notify(); -> No real need of this?
         }
 
         private void printItem(int index) {
@@ -42,9 +46,9 @@ public class FanOutFanIn {
         }
 
         void run() throws InterruptedException {
-            i = 0;
-            while (i <= 10) {
-                printNext();
+            i = 1;
+            while (i <= 10 ){
+                printNext(10);
             }
             /**
              * Current Problem: some numbers get printed twice
@@ -54,8 +58,8 @@ public class FanOutFanIn {
             // print 11 to 40 using 4 threads
             for (int j = 0; j < 4; j++) {
                 threads.add(new Thread(() -> {
-                    while (i <= 40) {
-                        printNext();
+                    while (i <= 40)  {
+                       printNext(40);
                     }
                 }));
             }
@@ -66,8 +70,8 @@ public class FanOutFanIn {
             }
 
             // print 41-50 using single thread again
-            while (i <= 50) {
-                printNext();
+            while (i <= 50 ) {
+                printNext(50);
             }
         }
     }


### PR DESCRIPTION
This is not exactly a fix but one way for threads to not print the values they were not supposed to print as per the original ask in the question.